### PR TITLE
Unbreak build with POSIX basename(3)

### DIFF
--- a/uhidd/uhidd.h
+++ b/uhidd/uhidd.h
@@ -392,8 +392,7 @@ struct evdev_cb {
 	do {								\
 		if (verbose >= (v)) {					\
 			char pb[64], pb2[1024];				\
-			snprintf(pb, sizeof(pb), "%s[%d]", basename(d),	\
-			    (n));					\
+			snprintf(pb, sizeof(pb), "%s[%d]", d, (n));	\
 			snprintf(pb2, sizeof(pb2), __VA_ARGS__);	\
 			printf("%s-> %s", pb, pb2);			\
 		}							\
@@ -404,7 +403,7 @@ struct evdev_cb {
 		if (verbose >= (v)) {					\
 			char pb[64], pb2[1024];				\
 			snprintf(pb, sizeof(pb), "%s[%d]",		\
-			    basename(hi->dev), hi->ndx);		\
+			    hi->dev, hi->ndx);				\
 			snprintf(pb2, sizeof(pb2), __VA_ARGS__);	\
 			printf("%s-> %s", pb, pb2);			\
 		}							\

--- a/uhidd/uhidd_cc.c
+++ b/uhidd/uhidd_cc.c
@@ -69,11 +69,11 @@ cc_write_keymap_file(struct hid_interface *hi)
 	int i;
 
 	snprintf(fpath, sizeof(fpath), "/var/run/uhidd.%s/cc_keymap",
-	    basename(hi->dev));
+	    hi->dev);
 	fp = fopen(fpath, "w+");
 	if (fp == NULL) {
 		syslog(LOG_ERR, "%s[%d] fopen %s failed: %m",
-		    basename(hi->dev), hi->ndx, fpath);
+		    hi->dev, hi->ndx, fpath);
 		return;
 	}
 	fprintf(fp, "0x%04x:0x%04x={\n", hi->vendor_id, hi->product_id);

--- a/uhidd/uhidd_evdev.c
+++ b/uhidd/uhidd_evdev.c
@@ -157,7 +157,7 @@ struct evmsg {
 		if (verbose >= (v)) {					\
 			char pb[64], pb2[1024];				\
 			snprintf(pb, sizeof(pb), "%s[%d][%s]",		\
-			    basename(hi->dev), hi->ndx, ed->devname);	\
+			    hi->dev, hi->ndx, ed->devname);		\
 			snprintf(pb2, sizeof(pb2), __VA_ARGS__);	\
 			printf("%s-> %s", pb, pb2);			\
 		}							\
@@ -168,7 +168,7 @@ struct evmsg {
 		if (verbose >= (v)) {					\
 			char pb[64], pb2[1024];				\
 			snprintf(pb, sizeof(pb), "%s[%d][%s][c:%d]",	\
-			    basename(hi->dev), hi->ndx, ed->devname,	\
+			    hi->dev, hi->ndx, ed->devname,		\
 				ec->ndx);				\
 			snprintf(pb2, sizeof(pb2), __VA_ARGS__);	\
 			printf("%s-> %s", pb, pb2);			\

--- a/uhidd/uhidd_kbd.c
+++ b/uhidd/uhidd_kbd.c
@@ -770,7 +770,7 @@ kbd_attach(struct hid_appcol *ha)
 		/* Open /dev/vkbdctl. */
 		if ((kd->vkbd_fd = open("/dev/vkbdctl", O_RDWR)) < 0) {
 			syslog(LOG_ERR, "%s[%d] could not open /dev/vkbdctl:"
-			    " %m", basename(hi->dev), hi->ndx);
+			    " %m", hi->dev, hi->ndx);
 			if (errno == ENOENT)
 				PRINT1(1, "vkbd.ko kernel module not "
 				    "loaded?\n");
@@ -780,7 +780,7 @@ kbd_attach(struct hid_appcol *ha)
 		if (verbose) {
 			if (fstat(kd->vkbd_fd, &sb) < 0) {
 				syslog(LOG_ERR, "%s[%d] fstat: /dev/vkbdctl:"
-				    " %m", basename(hi->dev), hi->ndx);
+				    " %m", hi->dev, hi->ndx);
 				return (-1);
 			}
 			PRINT1(1, "kbd device name: %s\n",
@@ -799,7 +799,7 @@ kbd_attach(struct hid_appcol *ha)
 		kd->evdev = evdev_register_device(kd, &kbd_evdev_cb);
 		if (kd->evdev == NULL) {
 			syslog(LOG_ERR, "%s[%d] could not register evdev "
-			    "device", basename(hi->dev), hi->ndx);
+			    "device", hi->dev, hi->ndx);
 			return (-1);
 		}
 		PRINT1(1, "kbd evdev device name: %s\n",

--- a/uhidd/uhidd_mouse.c
+++ b/uhidd/uhidd_mouse.c
@@ -93,7 +93,7 @@ mouse_attach(struct hid_appcol *ha)
 	md->cons_fd = open("/dev/consolectl", O_RDWR);
 	if (md->cons_fd < 0) {
 		syslog(LOG_ERR, "%s[%d] could not open /dev/consolectl: %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		return (-1);
 	}
 
@@ -213,5 +213,5 @@ mouse_recv(struct hid_appcol *ha, struct hid_report *hr)
 
 	if (ioctl(md->cons_fd, CONS_MOUSECTL, &mi) < 0)
 		syslog(LOG_ERR, "%s[%d] could not submit mouse data:"
-		    " ioctl failed: %m", basename(hi->dev), hi->ndx);
+		    " ioctl failed: %m", hi->dev, hi->ndx);
 }

--- a/uhidd/uhidd_vhid.c
+++ b/uhidd/uhidd_vhid.c
@@ -97,7 +97,7 @@ vhid_attach(struct hid_appcol *ha)
 	 */
 	if ((vd->vd_fd = open("/dev/uvhidctl", O_RDWR)) < 0) {
 		syslog(LOG_ERR, "%s[%d] could not open /dev/uvhidctl: %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		if (errno == ENOENT)
 			PRINT1(1, "uvhid.ko kernel moduel not loaded?\n")
 		return (-1);
@@ -105,13 +105,13 @@ vhid_attach(struct hid_appcol *ha)
 
 	if (fstat(vd->vd_fd, &sb) < 0) {
 		syslog(LOG_ERR, "%s[%d] fstat: /dev/uvhidctl: %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		close(vd->vd_fd);
 		return (-1);
 	}
 
 	if ((vd->vd_name = strdup(devname(sb.st_rdev, S_IFCHR))) == NULL) {
-		syslog(LOG_ERR, "%s[%d] strdup failed: %m", basename(hi->dev),
+		syslog(LOG_ERR, "%s[%d] strdup failed: %m", hi->dev,
 		    hi->ndx);
 		close(vd->vd_fd);
 		return (-1);
@@ -128,7 +128,7 @@ vhid_attach(struct hid_appcol *ha)
 
 	if (ioctl(vd->vd_fd, USB_SET_REPORT_DESC, &ugd) < 0) {
 		syslog(LOG_ERR, "%s[%d] ioctl(USB_SET_REPORT_DESC): %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		return (-1);
 	}
 
@@ -147,7 +147,7 @@ vhid_attach(struct hid_appcol *ha)
 
 	if (ioctl(vd->vd_fd, USB_SET_REPORT_ID, &vd->vd_rid) < 0) {
 		syslog(LOG_ERR, "%s[%d] ioctl(USB_SET_REPORT_ID): %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		return (-1);
 	}
 
@@ -155,7 +155,7 @@ vhid_attach(struct hid_appcol *ha)
 	e = pthread_create(&vd->vd_task, NULL, vhid_task, (void *) ha);
 	if (e) {
 		syslog(LOG_ERR, "%s[%d] pthread_create failed: %m",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		close(vd->vd_fd);
 		return (-1);
 	}
@@ -188,7 +188,7 @@ vhid_recv_raw(struct hid_appcol *ha, uint8_t *buf, int len)
 	}
 
 	if (write(vd->vd_fd, buf, len) < 0)
-		syslog(LOG_ERR, "%s[%d] write failed: %m", basename(hi->dev),
+		syslog(LOG_ERR, "%s[%d] write failed: %m", hi->dev,
 		    hi->ndx);
 }
 
@@ -209,7 +209,7 @@ vhid_task(void *arg)
 	assert(vd != NULL);
 
 	if ((buf = malloc(_TR_BUFSIZE)) == NULL) {
-		syslog(LOG_ERR, "%s[%d] malloc failed: %m", basename(hi->dev),
+		syslog(LOG_ERR, "%s[%d] malloc failed: %m", hi->dev,
 		    hi->ndx);
 		return (NULL);
 	}
@@ -223,7 +223,7 @@ vhid_task(void *arg)
 		}
 		if (verbose) {
 			PRINT1(1, "%s[%d] vhid_task recevied:",
-			    basename(hi->dev), hi->ndx);
+			    hi->dev, hi->ndx);
 			for (i = 0; i < len; i++)
 				printf("%d ", buf[i]);
 			putchar('\n');

--- a/uhidd/uhidd_vhid_cuse.c
+++ b/uhidd/uhidd_vhid_cuse.c
@@ -195,7 +195,7 @@ vhid_attach(struct hid_appcol *ha)
 		vd->vd_rsz = ha->ha_rsz;
 	} else {
 		syslog(LOG_ERR, "%s[%d] report descriptor too big!",
-		    basename(hi->dev), hi->ndx);
+		    hi->dev, hi->ndx);
 		return (-1);
 	}
 
@@ -471,7 +471,7 @@ vhid_write(struct cuse_dev *cdev, int fflags, const void *peer_ptr, int len)
 		goto write_done;
 
 	if (verbose) {
-		PRINT1(1, "%s[%d] vhid_task recevied:", basename(hi->dev),
+		PRINT1(1, "%s[%d] vhid_task recevied:", hi->dev,
 		    hi->ndx);
 		for (i = 0; i < len; i++)
 			printf("%d ", buf[i]);


### PR DESCRIPTION
Looking at the code with `git grep` it seems device file is never used without `basename()`. As FreeBSD 12.0 plans to drop `const` to chase POSIX this is going to break build. Rather than inject `__DECONST()` let's get rid of superfluous calls. Rebased from https://github.com/freebsd/freebsd-ports/commit/ffe6bc6eea3cf974a9e3407fb8ddf24e740c5ad7

http://pubs.opengroup.org/onlinepubs/9699919799/functions/basename.html
